### PR TITLE
Replace hero video with YouTube embed and fix sizing

### DIFF
--- a/client/components/Hero.tsx
+++ b/client/components/Hero.tsx
@@ -2,7 +2,7 @@ import { Button } from "@/components/ui/button";
 
 export default function Hero() {
   return (
-    <section className="relative min-h-screen flex items-center justify-center overflow-hidden">
+    <section className="relative h-screen flex items-center justify-center overflow-hidden">
       {/* Background Video */}
       <div className="absolute inset-0">
         <iframe

--- a/client/components/Hero.tsx
+++ b/client/components/Hero.tsx
@@ -5,16 +5,13 @@ export default function Hero() {
     <section className="relative min-h-screen flex items-center justify-center overflow-hidden">
       {/* Background Video */}
       <div className="absolute inset-0">
-        <video
-          autoPlay
-          muted
-          loop
-          playsInline
+        <iframe
+          src="https://player.vimeo.com/video/1112021062?background=1&autoplay=1&loop=1&byline=0&title=0&muted=1"
           className="absolute inset-0 w-full h-full object-cover"
-        >
-          <source src="/videos/hero-background.mp4" type="video/mp4" />
-          Your browser does not support the video tag.
-        </video>
+          frameBorder="0"
+          allow="autoplay; fullscreen; picture-in-picture"
+          style={{ pointerEvents: 'none' }}
+        ></iframe>
         <div className="absolute inset-0 bg-gradient-to-br from-gray-900/70 via-black/50 to-redtools-red/30"></div>
         {/* Geometric pattern overlay */}
         <div className="absolute inset-0 opacity-10">

--- a/client/components/Hero.tsx
+++ b/client/components/Hero.tsx
@@ -11,9 +11,9 @@ export default function Hero() {
           frameBorder="0"
           allow="autoplay; fullscreen; picture-in-picture"
           style={{
-            pointerEvents: 'none',
-            minWidth: '100%',
-            minHeight: '100%'
+            pointerEvents: "none",
+            minWidth: "100%",
+            minHeight: "100%",
           }}
         ></iframe>
         {/* Cover YouTube watermark */}

--- a/client/components/Hero.tsx
+++ b/client/components/Hero.tsx
@@ -6,11 +6,15 @@ export default function Hero() {
       {/* Background Video */}
       <div className="absolute inset-0">
         <iframe
-          src="https://www.youtube.com/embed/-ZeW7YEiwC0?autoplay=1&mute=1&loop=1&playlist=-ZeW7YEiwC0&controls=0&showinfo=0&rel=0&iv_load_policy=3&modestbranding=1"
-          className="absolute inset-0 w-full h-full object-cover"
+          src="https://www.youtube.com/embed/sbUFN2o880M?autoplay=1&mute=1&loop=1&playlist=sbUFN2o880M&controls=0&showinfo=0&rel=0&iv_load_policy=3&modestbranding=1"
+          className="absolute inset-0 w-full h-full"
           frameBorder="0"
           allow="autoplay; fullscreen; picture-in-picture"
-          style={{ pointerEvents: 'none' }}
+          style={{
+            pointerEvents: 'none',
+            minWidth: '100%',
+            minHeight: '100%'
+          }}
         ></iframe>
         {/* Cover YouTube watermark */}
         <div className="absolute bottom-4 right-4 w-16 h-8 bg-black/90 z-5"></div>

--- a/client/components/Hero.tsx
+++ b/client/components/Hero.tsx
@@ -6,7 +6,7 @@ export default function Hero() {
       {/* Background Video */}
       <div className="absolute inset-0">
         <iframe
-          src="https://player.vimeo.com/video/1112021062?background=1&autoplay=1&loop=1&byline=0&title=0&muted=1"
+          src="https://www.youtube.com/embed/-ZeW7YEiwC0?autoplay=1&mute=1&loop=1&playlist=-ZeW7YEiwC0&controls=0&showinfo=0&rel=0&iv_load_policy=3&modestbranding=1"
           className="absolute inset-0 w-full h-full object-cover"
           frameBorder="0"
           allow="autoplay; fullscreen; picture-in-picture"

--- a/client/components/Hero.tsx
+++ b/client/components/Hero.tsx
@@ -12,6 +12,8 @@ export default function Hero() {
           allow="autoplay; fullscreen; picture-in-picture"
           style={{ pointerEvents: 'none' }}
         ></iframe>
+        {/* Cover YouTube watermark */}
+        <div className="absolute bottom-4 right-4 w-16 h-8 bg-black/90 z-5"></div>
         <div className="absolute inset-0 bg-gradient-to-br from-gray-900/70 via-black/50 to-redtools-red/30"></div>
         {/* Geometric pattern overlay */}
         <div className="absolute inset-0 opacity-10">


### PR DESCRIPTION
## Purpose

The user wanted to update the hero section's background video to use a specific YouTube video (https://youtu.be/sbUFN2o880M) instead of a local video file. They also needed to ensure the video fills the entire container without gaps and hide the YouTube watermark that appears in the bottom-right corner.

## Code changes

- **Replaced video element with YouTube iframe**: Changed from a local `<video>` element using `/videos/hero-background.mp4` to a YouTube embed iframe with the specified video ID `sbUFN2o880M`
- **Updated container sizing**: Changed hero section from `min-h-screen` to `h-screen` to eliminate gaps and ensure full viewport coverage
- **Added YouTube embed parameters**: Configured iframe with autoplay, mute, loop, no controls, and modest branding to create a seamless background video experience
- **Added watermark cover**: Implemented a black overlay div positioned at `bottom-4 right-4` to hide the YouTube watermark without affecting other elements
- **Enhanced iframe styling**: Added `pointerEvents: "none"` and minimum width/height properties to ensure the video fills the entire container properly

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/3c4a5dbaefb04c288c20c82ac858dc1e/zenith-home)

👀 [Preview Link](https://3c4a5dbaefb04c288c20c82ac858dc1e-zenith-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3c4a5dbaefb04c288c20c82ac858dc1e</projectId>-->
<!--<branchName>zenith-home</branchName>-->